### PR TITLE
Feat/auto assign types

### DIFF
--- a/FlatCrawler.ConsoleApp/Crawler/ConsoleCrawler.cs
+++ b/FlatCrawler.ConsoleApp/Crawler/ConsoleCrawler.cs
@@ -15,13 +15,12 @@ namespace FlatCrawler.ConsoleApp
         private readonly List<string> ProcessedCommands = new();
         private const string SaveStatePath = "lines.txt";
 
-        private readonly byte[] Data;
         private readonly string FilePath;
 
         public ConsoleCrawler(string path, byte[] data)
         {
             FilePath = path;
-            Data = data;
+            CommandUtil.Data = data;
         }
 
         public void CrawlLoop()
@@ -30,7 +29,7 @@ namespace FlatCrawler.ConsoleApp
             Console.WriteLine($"Crawling {Console.Title = fn}...");
             Console.WriteLine();
 
-            FlatBufferNode node = FlatBufferRoot.Read(0, Data);
+            FlatBufferNode node = FlatBufferRoot.Read(0, CommandUtil.Data.ToArray());
             node.PrintTree();
 
             Console.OutputEncoding = Encoding.UTF8; // japanese strings will show up as boxes rather than ????
@@ -40,7 +39,7 @@ namespace FlatCrawler.ConsoleApp
                 var cmd = Console.ReadLine();
                 if (cmd is null)
                     break;
-                var result = ProcessCommand(cmd, ref node, Data);
+                var result = ProcessCommand(cmd, ref node, CommandUtil.Data.ToArray());
                 if (result == CrawlResult.Quit)
                     break;
 

--- a/FlatCrawler.Lib/Model/Nodes/FlatBufferNode.cs
+++ b/FlatCrawler.Lib/Model/Nodes/FlatBufferNode.cs
@@ -1,7 +1,19 @@
-﻿using System.Xml.Linq;
+﻿using System;
 
 namespace FlatCrawler.Lib
 {
+    public sealed record FlatBufferNodeType
+    {
+        public TypeCode Type { get; init; } = TypeCode.Empty;
+        public bool IsArray { get; init; } = false;
+
+        public FlatBufferNodeType(TypeCode type, bool isArray)
+        {
+            Type = type;
+            IsArray = isArray;
+        }
+    }
+
     public abstract record FlatBufferNode
     {
         public readonly FlatBufferNode? Parent;

--- a/FlatCrawler.Lib/Model/Nodes/Object/FlatBufferNodeField.cs
+++ b/FlatCrawler.Lib/Model/Nodes/Object/FlatBufferNodeField.cs
@@ -54,7 +54,17 @@ namespace FlatCrawler.Lib
 
         protected static VTable ReadVTable(int offset, byte[] data) => new(data, offset);
 
-        public void TrackChildFieldNode(int fieldIndex, FlatBufferNode node) => Fields[fieldIndex] = node;
+        public void TrackChildFieldNode(int fieldIndex, TypeCode code, bool asArray, FlatBufferNode node)
+        {
+            // Table objects have the same data types for each entry
+            if (Parent is FlatBufferTableObject t)
+            {
+                t.OnFieldTypeChanged(fieldIndex, code, asArray, this);
+            }
+
+            Fields[fieldIndex] = node;
+        }
+
         public void SetFieldHint(int fieldIndex, string type) => VTable.FieldInfo[fieldIndex].TypeHint = type;
 
         public FlatBufferNode GetFieldValue(int fieldIndex, byte[] data, TypeCode type) => type switch
@@ -104,6 +114,11 @@ namespace FlatCrawler.Lib
 #pragma warning restore format
             _ => throw new ArgumentOutOfRangeException(nameof(type)),
         };
+
+        public void UpdateNodeType(int fieldIndex, byte[] data, TypeCode type, bool asArray)
+        {
+            Fields[fieldIndex] = ReadNode(fieldIndex, data, type, asArray);
+        }
 
         public FlatBufferNode ReadNode(int fieldIndex, byte[] data, TypeCode type, bool asArray)
         {

--- a/FlatCrawler.Lib/Util/CommandUtil.cs
+++ b/FlatCrawler.Lib/Util/CommandUtil.cs
@@ -54,7 +54,7 @@ namespace FlatCrawler.Lib
             FlatBufferNode result = node.ReadNode(fieldIndex, data, code, asArray);
 
             node.SetFieldHint(fieldIndex, type);
-            node.TrackChildFieldNode(fieldIndex, result);
+            node.TrackChildFieldNode(fieldIndex, code, asArray, result);
             return result;
         }
     }

--- a/FlatCrawler.Lib/Util/CommandUtil.cs
+++ b/FlatCrawler.Lib/Util/CommandUtil.cs
@@ -5,6 +5,9 @@ namespace FlatCrawler.Lib
 {
     public static class CommandUtil
     {
+        // TODO: Make a nice wrapper class for file data
+        public static ReadOnlyMemory<byte> Data { get; set; }
+
         private static TypeCode GetTypeCode(string type) => type.Replace(" ", "").Replace("[]", "") switch
         {
             "bool" => TypeCode.Boolean,


### PR DESCRIPTION
From the [FlatCC documentation](https://github.com/dvidelabs/flatcc/blob/master/doc/binary-format.md#memory-blocks):
> All elements of a vector have the same type. Which is either a scalar type (including enums), a struct, or a `uoffset` reference where all the references point to tables all of the same type, all strings, or, for union vectors, references to members of the same union.

- Adds type information to `FlatBufferTableObject`'s
- Setting the type of a FlatBufferObject's member field will now update all sibling objects with the new type. This is done by tracking class references in the `FlatBufferTableObject`'s


_Note: Support for arrays, structs and FlatBufferObject's without table still needs to added. The current implementation is feature complete and won't break because they are missing._
